### PR TITLE
feat: add OTLP configuration to Docker Compose and documentation

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -66,6 +66,13 @@ services:
       CORS_ORIGINS: "*"
       CORS_CREDENTIALS: true
 
+      # OTLP Settings
+      OTLP_HTTP_ENABLED: ${OTLP_HTTP_ENABLED:-true}
+      OTLP_HTTP_PATH: ${OTLP_HTTP_PATH:-/v1/traces}
+      OTLP_GRPC_ENABLED: ${OTLP_GRPC_ENABLED:-true}
+      OTLP_GRPC_HOST: ${OTLP_GRPC_HOST:-0.0.0.0}
+      OTLP_GRPC_PORT: ${OTLP_GRPC_PORT:-4317}
+
       # Performance Settings
       MAX_TRACE_SIZE_MB: ${MAX_TRACE_SIZE_MB:-50}
       REQUEST_TIMEOUT: ${REQUEST_TIMEOUT:-60}
@@ -74,7 +81,8 @@ services:
       LOG_LEVEL: DEBUG
       LOG_FORMAT: text
     ports:
-      - "8000:8000"
+      - "8000:8000" # Main API
+      - "4317:4317" # OTLP gRPC
     volumes:
       # Mount source code for development
       - ../src:/app/src:ro

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -66,6 +66,13 @@ services:
       CORS_ORIGINS: "*"
       CORS_CREDENTIALS: ${CORS_CREDENTIALS:-true}
 
+      # OTLP Settings
+      OTLP_HTTP_ENABLED: ${OTLP_HTTP_ENABLED:-true}
+      OTLP_HTTP_PATH: ${OTLP_HTTP_PATH:-/v1/traces}
+      OTLP_GRPC_ENABLED: ${OTLP_GRPC_ENABLED:-true}
+      OTLP_GRPC_HOST: ${OTLP_GRPC_HOST:-0.0.0.0}
+      OTLP_GRPC_PORT: ${OTLP_GRPC_PORT:-4317}
+
       # Performance Settings
       MAX_TRACE_SIZE_MB: ${MAX_TRACE_SIZE_MB:-10}
       REQUEST_TIMEOUT: ${REQUEST_TIMEOUT:-30}
@@ -74,7 +81,8 @@ services:
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       LOG_FORMAT: ${LOG_FORMAT:-json}
     ports:
-      - "8000:8000"
+      - "8000:8000"  # Main API
+      - "4317:4317"  # OTLP gRPC
     volumes:
       - sqlite_data:/app/data
     depends_on:

--- a/docs/OTLP_INTEGRATION.md
+++ b/docs/OTLP_INTEGRATION.md
@@ -66,7 +66,7 @@ graph TB
 
 ### OTLP HTTP Receiver
 
-**Endpoint**: `POST /v1/traces/`
+**Endpoint**: `POST /v1/traces/` (shares main API port 8000)
 
 **Features**:
 
@@ -75,6 +75,7 @@ graph TB
 - Batch span processing
 - Real-time WebSocket broadcasting
 - Incremental trace updates
+- Configurable path via `OTLP_HTTP_PATH`
 
 **Example Request**:
 
@@ -94,6 +95,8 @@ curl -X POST http://localhost:8000/v1/traces/ \
 - Async processing
 - Batch export support
 - Real-time WebSocket broadcasting
+- Dedicated port (default: 4317)
+- Configurable host and port via `OTLP_GRPC_HOST` and `OTLP_GRPC_PORT`
 
 **Example Client**:
 
@@ -278,12 +281,13 @@ async def send_otlp_grpc():
 
 ### Environment Variables
 
-| Variable            | Default | Description               |
-| ------------------- | ------- | ------------------------- |
-| `OTLP_HTTP_ENABLED` | `true`  | Enable OTLP HTTP receiver |
-| `OTLP_GRPC_ENABLED` | `true`  | Enable OTLP gRPC receiver |
-| `OTLP_HTTP_PORT`    | `8000`  | HTTP receiver port        |
-| `OTLP_GRPC_PORT`    | `4317`  | gRPC receiver port        |
+| Variable            | Default      | Description                               |
+| ------------------- | ------------ | ----------------------------------------- |
+| `OTLP_HTTP_ENABLED` | `true`       | Enable OTLP HTTP receiver                 |
+| `OTLP_HTTP_PATH`    | `/v1/traces` | HTTP receiver path (shares main API port) |
+| `OTLP_GRPC_ENABLED` | `true`       | Enable OTLP gRPC receiver                 |
+| `OTLP_GRPC_HOST`    | `0.0.0.0`    | gRPC receiver host                        |
+| `OTLP_GRPC_PORT`    | `4317`       | gRPC receiver port                        |
 
 ### Docker Configuration
 
@@ -291,11 +295,14 @@ async def send_otlp_grpc():
 services:
   agent-spy:
     ports:
-      - "8000:8000" # OTLP HTTP
-      - "4317:4317" # OTLP gRPC
+      - "8000:8000" # Main API + OTLP HTTP (shared port)
+      - "4317:4317" # OTLP gRPC (dedicated port)
     environment:
       - OTLP_HTTP_ENABLED=true
+      - OTLP_HTTP_PATH=/v1/traces
       - OTLP_GRPC_ENABLED=true
+      - OTLP_GRPC_HOST=0.0.0.0
+      - OTLP_GRPC_PORT=4317
 ```
 
 ## Performance Considerations

--- a/env.example
+++ b/env.example
@@ -74,6 +74,19 @@ BACKEND_PORT=8000
 FRONTEND_PORT=80
 
 # =============================================================================
+# OTLP SETTINGS
+# =============================================================================
+
+# OTLP HTTP receiver settings (shares main API port 8000)
+OTLP_HTTP_ENABLED=true
+OTLP_HTTP_PATH=/v1/traces
+
+# OTLP gRPC receiver settings (dedicated port)
+OTLP_GRPC_ENABLED=true
+OTLP_GRPC_HOST=0.0.0.0
+OTLP_GRPC_PORT=4317
+
+# =============================================================================
 # CORS SETTINGS
 # =============================================================================
 


### PR DESCRIPTION
- Add OTLP HTTP and gRPC configuration to docker-compose.yml and docker-compose.dev.yml
- Expose OTLP gRPC port 4317 in both Docker Compose files
- Add OTLP environment variables to env.example with clear documentation
- Update README.md with OTLP endpoint information and configuration details
- Clarify that OTLP HTTP shares main API port (8000) while gRPC uses dedicated port (4317)
- Update OTLP_INTEGRATION.md with Docker configuration examples
- Add comprehensive OTLP configuration documentation
- Include OTLP environment variables in Docker Compose environment sections
- Document OTLP path configuration and port sharing architecture